### PR TITLE
fix bug ; new get_called_class() => Error: Class 'get_called_class' n…

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -186,7 +186,8 @@ abstract class ActiveRecord extends Base {
      */
     public static function _query($sql, $param = array(), $obj = null, $single=false) {
         if ($sth = self::$db->prepare($sql)) {
-            $sth->setFetchMode( PDO::FETCH_INTO , ($obj ? $obj : new get_called_class()));
+            $called_class = get_called_class();
+	    $sth->setFetchMode( PDO::FETCH_INTO , ($obj ? $obj : new $called_class ));
             $sth->execute($param);
             if ($single) return $sth->fetch( PDO::FETCH_INTO ) ? $obj->dirty() : false;
             $result = array();

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "victorruan/activerecord",
+    "name": "bephp/activerecord",
     "type": "library",
     "description": "micro activerecord library in PHP(only 400 lines with comments), support chain calls and relations(HAS_ONE, HAS_MANY, BELONGS_TO).",
     "keywords": ["activerecord", "orm", "pdo", "relation", "micro", "database"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bephp/activerecord",
+    "name": "victorruan/activerecord",
     "type": "library",
     "description": "micro activerecord library in PHP(only 400 lines with comments), support chain calls and relations(HAS_ONE, HAS_MANY, BELONGS_TO).",
     "keywords": ["activerecord", "orm", "pdo", "relation", "micro", "database"],


### PR DESCRIPTION
修复在命民空间下调用
 `new get_called_class()`
会出现 Error: Class 'get_called_class' ```
的问题
